### PR TITLE
Prepare for a breaking change in the Rust compiler.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl DBImpl {
     **Parameter**:
     - `table_name`: Name of the table to delete from.
     */
-    pub fn delete<'until_build, 'post_query>(
+    pub fn delete<'until_build, 'post_query: 'until_build>(
         &self,
         table_name: &'until_build str,
     ) -> impl Delete<'until_build, 'post_query> {
@@ -405,7 +405,7 @@ impl DBImpl {
     **Parameter**:
     - `table_name`: Name of the table the updates should be executed for.
     */
-    pub fn update<'until_build, 'post_query>(
+    pub fn update<'until_build, 'post_query: 'until_build>(
         &self,
         table_name: &'until_build str,
     ) -> impl Update<'until_build, 'post_query> {


### PR DESCRIPTION
The soundness fix in rust-lang/rust#115008 will cause rorm-sql to break, even though it is not unsound. The missing bound is very hard to abuse, but still a soundness hole in our type system.

It will likely take 12 weeks before a stable compiler with the soundness fix is shipped.